### PR TITLE
Added SDCard for Android

### DIFF
--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -207,6 +207,7 @@ public class RNFetchBlobFS {
         res.put("DownloadDir", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath());
         res.put("MovieDir", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES).getAbsolutePath());
         res.put("RingtoneDir", Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_RINGTONES).getAbsolutePath());
+        res.put("SDCard", Environment.getExternalStorageDirectory().getAbsolutePath());
         return res;
     }
 

--- a/src/fs.js
+++ b/src/fs.js
@@ -28,7 +28,8 @@ const dirs = {
     MusicDir : RNFetchBlob.MusicDir,
     MovieDir : RNFetchBlob.MovieDir,
     DownloadDir : RNFetchBlob.DownloadDir,
-    DCIMDir : RNFetchBlob.DCIMDir
+    DCIMDir : RNFetchBlob.DCIMDir,
+    SDCardDir : RNFetchBlob.SDCardDir
 }
 
 /**


### PR DESCRIPTION
Getting the base directory of the phone is pretty helpful, as you can create your own Application folder like applications like Whatsapp or Instagram do.
That is especially needed when you want to share files with other applications but not put them just in the `DocumentDir` or other public dirs.

Simply create your folder in 
```js
fs.dirs.SDCardDir + '/YourApp'
```
