### PR TITLE
Fix XMLHttpRequest event listeners

### DIFF
--- a/src/polyfill/EventTarget.js
+++ b/src/polyfill/EventTarget.js
@@ -51,13 +51,14 @@ export default class EventTarget {
 
   /**
    * Dispatch an event
-   * @param {Evnet} event Event data payload.
+   * @param {string} type Event type.
+   * @param {Event} event Event data payload.
    */
-  dispatchEvent(event:Event) {
+  dispatchEvent(type:string,event:Event) {
     log.info('dispatch event', event)
-    if(!(event.type in this.listeners))
+    if(!(type in this.listeners))
       return
-    let handlers = this.listeners[event.type]
+    let handlers = this.listeners[type]
     for(let i in handlers) {
       handlers[i].call(this, event)
     }
@@ -71,7 +72,7 @@ export default class EventTarget {
    */
   clearEventListeners() {
     for(let i in this.listeners) {
-      delete listeners[i]
+      delete this.listeners[i]
     }
   }
 


### PR DESCRIPTION
This PR fixes #187 and #179, by making the dispatch of events to listeners and the removal of listeners work in the XMLHttpRequest polyfill. 

Problems occurring with the newest version of firebase (3.6.1), which probably makes use of event listeners, should be solved now. 