### PR TITLE
Long multipart upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,48 @@ What if you want to append a file to form data ? Just like [upload a file from s
   })
 ```
 
+When you append files to form-data and you want to continue uploading while the app is in background on Android, you can use IntentService to upload by adding `multipartFileUpload` flag to config.
+
+```js
+
+  RNFetchBlob.config({
+    multipartFileUpload: true,
+  })
+  .fetch('POST', 'http://www.example.com/upload-form', {
+    Authorization : "Bearer access-token",
+    otherHeader : "foo",
+    // this is required, otherwise it won't be process as a multipart/form-data request
+    'Content-Type' : 'multipart/form-data',
+  }, [
+    // append field data from file path
+    {
+      name : 'avatar',
+      filename : 'avatar.png',
+      // Change BASE64 encoded data to a file path with prefix `RNFetchBlob-file://`.
+      // Or simply wrap the file path with RNFetchBlob.wrap().
+      data: RNFetchBlob.wrap(PATH_TO_THE_FILE)
+    },
+    {
+      name : 'ringtone',
+      filename : 'ring.mp3',
+      // use custom MIME type
+      type : 'application/mp3',
+      // upload a file from asset is also possible in version >= 0.6.2
+      data : RNFetchBlob.wrap(RNFetchBlob.fs.asset('default-ringtone.mp3'))
+    }
+    // elements without property `filename` will be sent as plain text
+    { name : 'name', data : 'user'},
+    { name : 'info', data : JSON.stringify({
+      mail : 'example@example.com',
+      tel : '12345678'
+    })},
+  ]).then((resp) => {
+    // ...
+  }).catch((err) => {
+    // ...
+  })
+```
+
 ### Upload/Download progress
 
 In `version >= 0.4.2` it is possible to know the upload/download progress. After `0.7.0` IOS and Android upload progress are also supported.

--- a/src/android/src/main/AndroidManifest.xml
+++ b/src/android/src/main/AndroidManifest.xml
@@ -6,6 +6,10 @@
         android:label="@string/app_name"
         android:supportsRtl="true">
 
+        <service
+            android:name=".RNFetchBlobService"
+            >
+        </service>
     </application>
 
 </manifest>

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
@@ -20,7 +20,7 @@ public class RNFetchBlobConfig {
     public long timeout = 60000;
     public Boolean increment = false;
     public ReadableArray binaryContentTypes = null;
-    public Boolean largeFileUpload;
+    public boolean largeFileUpload;
 
     RNFetchBlobConfig(ReadableMap options) {
         if(options == null)

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
@@ -20,6 +20,7 @@ public class RNFetchBlobConfig {
     public long timeout = 60000;
     public Boolean increment = false;
     public ReadableArray binaryContentTypes = null;
+    public Boolean largeFileUpload;
 
     RNFetchBlobConfig(ReadableMap options) {
         if(options == null)
@@ -46,6 +47,7 @@ public class RNFetchBlobConfig {
         if(options.hasKey("timeout")) {
             this.timeout = options.getInt("timeout");
         }
+        this.largeFileUpload = options.hasKey("largeFileUpload") ? options.getBoolean("largeFileUpload") : false;
     }
 
 }

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
@@ -20,7 +20,7 @@ public class RNFetchBlobConfig {
     public long timeout = 60000;
     public Boolean increment = false;
     public ReadableArray binaryContentTypes = null;
-    public boolean largeFileUpload;
+    public boolean multipartFileUpload;
 
     RNFetchBlobConfig(ReadableMap options) {
         if(options == null)
@@ -47,7 +47,7 @@ public class RNFetchBlobConfig {
         if(options.hasKey("timeout")) {
             this.timeout = options.getInt("timeout");
         }
-        this.largeFileUpload = options.hasKey("largeFileUpload") ? options.getBoolean("largeFileUpload") : false;
+        this.multipartFileUpload = options.hasKey("multipartFileUpload") ? options.getBoolean("multipartFileUpload") : false;
     }
 
 }

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -698,36 +698,37 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
 
             }
         } else if (RNFetchBlobService.RNFetchBlobServiceBroadcast.equals(action)) {
-            if (intent.hasCategory(RNFetchBlobService.CategoryProgress)) {
-                HashMap map = (HashMap)intent.getSerializableExtra(RNFetchBlobService.BroadcastProgressMap);
-                String taskId = (String)map.get(RNFetchBlobService.KeyTaskId);
-                WritableMap args = Arguments.createMap();
-                args.putString("taskId", taskId);
-                args.putString("written", String.valueOf(map.get(RNFetchBlobService.KeyWritten)));
-                args.putString("total", String.valueOf(map.get(RNFetchBlobService.KeyTotal)));
+            String _taskId = intent.getStringExtra(RNFetchBlobService.BroadcastTaskId);
+            if (this.taskId.equals(_taskId)) {
+                if (intent.hasCategory(RNFetchBlobService.CategoryProgress)) {
+                    HashMap map = (HashMap) intent.getSerializableExtra(RNFetchBlobService.BroadcastProgressMap);
 
-                // emit event to js context
-                RNFetchBlob.RCTContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit(RNFetchBlobConst.EVENT_UPLOAD_PROGRESS, args);
-            } else if (intent.hasCategory(RNFetchBlobService.CategorySuccess)) {
-                // Could be fail.
-                try {
-                    byte[] bytes = intent.getByteArrayExtra(RNFetchBlobService.BroadcastMsg);
-                    callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_UTF8, new String(bytes, "UTF-8"));
-                } catch (IOException e) {
-                    callback.invoke("RNFetchBlob failed to encode response data to UTF8 string.", null);
-                } finally {
-                    // lets unregister.
+                    WritableMap args = Arguments.createMap();
+                    args.putString("taskId", _taskId);
+                    args.putString("written", String.valueOf(map.get(RNFetchBlobService.KeyWritten)));
+                    args.putString("total", String.valueOf(map.get(RNFetchBlobService.KeyTotal)));
+
+                    // emit event to js context
+                    RNFetchBlob.RCTContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                            .emit(RNFetchBlobConst.EVENT_UPLOAD_PROGRESS, args);
+                } else if (intent.hasCategory(RNFetchBlobService.CategorySuccess)) {
+                    // Could be fail.
+                    try {
+                        byte[] bytes = intent.getByteArrayExtra(RNFetchBlobService.BroadcastMsg);
+                        callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_UTF8, new String(bytes, "UTF-8"));
+                    } catch (IOException e) {
+                        callback.invoke("RNFetchBlob failed to encode response data to UTF8 string.", null);
+                    } finally {
+                        // lets unregister.
+                        Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
+                        appCtx.unregisterReceiver(this);
+                    }
+                } else if (intent.hasCategory(RNFetchBlobService.CategoryFail)) {
+                    callback.invoke("Request failed.", null, null);
                     Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
                     appCtx.unregisterReceiver(this);
                 }
-            } else if (intent.hasCategory(RNFetchBlobService.CategoryFail)) {
-                callback.invoke("Request failed.", null, null);
-                Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
-                appCtx.unregisterReceiver(this);
             }
         }
     }
-
-
 }

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -167,7 +167,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
 
         }
 
-        if(this.options.largeFileUpload) {
+        if(this.options.multipartFileUpload) {
             HashMap<String, String> mheaders = new HashMap<>();
             // set headers
             if (headers != null) {

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
@@ -4,6 +4,7 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 
 import com.facebook.react.modules.network.*;
 
@@ -78,17 +79,16 @@ public class RNFetchBlobService extends IntentService implements ProgressListene
                         : MediaType.parse("application/octet-stream");
                 if(filename != null && data.startsWith("RNFetchBlob-")) {
                     try {
-                        String newData = data.replace(RNFetchBlobConst.FILE_PREFIX, "");
-                        String normalizedUri = RNFetchBlobFS.normalizePath(newData);
+                        String normalizedUri = RNFetchBlobFS.normalizePath(data.replace(RNFetchBlobConst.FILE_PREFIX, ""));
                         file = new File(String.valueOf(Uri.parse(normalizedUri)));
                     } catch (Exception e) {
-                        //
+                        file = null;
                     }
                 }
 
                 String contentDisposition = "form-data"
-                        + (name != null && name.length() > 0 ? "; name=" + name : "")
-                        + (filename != null && filename.length() > 0 ? "; filename=" + filename : "");
+                        + (!TextUtils.isEmpty(name) ? "; name=" + name : "")
+                        + (!TextUtils.isEmpty(filename) ? "; filename=" + filename : "");
 
                 requestBuilder.addPart(
                         Headers.of("Content-Disposition", contentDisposition),

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
@@ -1,0 +1,187 @@
+package com.RNFetchBlob;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import com.facebook.react.modules.network.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * Created by pkwak on 11/15/16.
+ * IntentService for POSTing multi-form data. Designed for long-uploads with file
+ * (but can use data body).
+ */
+
+public class RNFetchBlobService extends IntentService implements ProgressListener {
+    public static String RNFetchBlobServiceBroadcast = "RNFetchBlobServiceBroadcast";
+
+    public static String CategorySuccess = "CategorySuccess";
+    public static String CategoryFail = "CategoryFail";
+    public static String CategoryProgress = "CategoryProgress";
+
+    public static String BroadcastMsg = "BroadcastMsg";
+    public static String BroadcastProgressMap = "BroadcastProgressMap";
+
+    public static String KeyTaskId = "KeyTaskId";
+    public static String KeyWritten = "KeyWritten";
+    public static String KeyTotal = "KeyTotal";
+
+    /**
+     * Creates an IntentService.  Invoked by your subclass's constructor.
+     */
+    public RNFetchBlobService() {
+        super("RNFetchBlobService");
+    }
+
+    private String _taskId = null;
+    @Override
+    protected void onHandleIntent(final Intent intent) {
+
+        Bundle bundle = intent.getExtras();
+        _taskId = bundle.getString("taskId");
+        String url = bundle.getString("url");
+        HashMap<String, String> mheaders = (HashMap<String, String>)bundle.getSerializable("mheaders");
+        ArrayList<Object> requestBodyArray = (ArrayList<Object>)bundle.getSerializable("requestBodyArray");
+
+        MultipartBody.Builder requestBuilder = new MultipartBody.Builder()
+                .setType(MultipartBody.FORM);
+        for(Object bodyPart : requestBodyArray) {
+            if (bodyPart instanceof HashMap) {
+                HashMap<String, String> bodyMap = (HashMap<String, String>)bodyPart;
+                String name = bodyMap.get("name");
+                String type = bodyMap.get("type");
+                String filename = bodyMap.get("filename");
+                String data = bodyMap.get("data");
+                File file = null;
+                MediaType mediaType = type != null
+                    ? MediaType.parse(type)
+                    : filename == null
+                        ? MediaType.parse("text/plain")
+                        : MediaType.parse("application/octet-stream");
+                if(filename != null && data.startsWith("RNFetchBlob-")) {
+                    try {
+                        String newData = data.replace(RNFetchBlobConst.FILE_PREFIX, "");
+                        String normalizedUri = RNFetchBlobFS.normalizePath(newData);
+                        file = new File(String.valueOf(Uri.parse(normalizedUri)));
+                    } catch (Exception e) {
+                        //
+                    }
+                }
+
+                String contentDisposition = "form-data"
+                        + (name != null && name.length() > 0 ? "; name=" + name : "")
+                        + (filename != null && filename.length() > 0 ? "; filename=" + filename : "");
+
+                requestBuilder.addPart(
+                        Headers.of("Content-Disposition", contentDisposition),
+                        file != null
+                                ? RequestBody.create(mediaType, file)
+                                : RequestBody.create(mediaType, data)
+                );
+            }
+        }
+        RequestBody innerRequestBody = requestBuilder.build();
+
+        ProgressRequestBody requestBody = new ProgressRequestBody(innerRequestBody, this);
+
+        final Request.Builder builder = new Request.Builder();
+        try {
+            builder.url(new URL(url));
+        } catch (MalformedURLException e) {
+            Intent broadcastIntent = new Intent();
+            broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
+            broadcastIntent.addCategory(CategoryFail);
+            broadcastIntent.putExtra(BroadcastMsg, "Could not create URL : " + e.getMessage().getBytes());
+            sendBroadcast(broadcastIntent);
+            return;
+        }
+
+        builder.post(requestBody);
+        for(String key : mheaders.keySet()) {
+            builder.addHeader(key, mheaders.get(key));
+        }
+
+        OkHttpClient client = new OkHttpClient.Builder()
+                .writeTimeout(24, TimeUnit.HOURS)
+                .readTimeout(24, TimeUnit.HOURS)
+                .build();
+
+        final Call call =  client.newCall(builder.build());
+        call.enqueue(new okhttp3.Callback() {
+
+            @Override
+            public void onFailure(Call call, IOException e) {
+                Intent broadcastIntent = new Intent();
+                broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
+                broadcastIntent.addCategory(CategoryFail);
+                broadcastIntent.putExtra(BroadcastMsg, e.getMessage().getBytes());
+                sendBroadcast(broadcastIntent);
+                call.cancel();
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                // This is http-response success. Can be 2xx/4xx/5xx/etc.
+                Intent broadcastIntent = new Intent();
+                broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
+                broadcastIntent.addCategory(CategorySuccess);
+                broadcastIntent.putExtra(BroadcastMsg, response.body().bytes());
+                sendBroadcast(broadcastIntent);
+
+                response.body().close();
+
+            }
+
+        });
+    }
+
+    private int _progressPercent = 0;
+    private long _lastProgressTime = 0;
+    @Override
+    public void onProgress(long bytesWritten, long contentLength, boolean done) {
+
+        // no more than once per %
+        int currentPercent = (int)((bytesWritten * 100) / contentLength);
+        if (currentPercent <= _progressPercent) {
+            return;
+        }
+        _progressPercent = currentPercent;
+
+        // no more than twice a second.
+        long now = System.currentTimeMillis();
+        if (_lastProgressTime + 500 > now) {
+            return;
+        }
+        _lastProgressTime = now;
+
+        Intent broadcastIntent = new Intent();
+        broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
+        broadcastIntent.addCategory(CategoryProgress);
+        HashMap map = new HashMap();
+        map.put(KeyWritten, Long.valueOf(bytesWritten));
+        map.put(KeyTotal, Long.valueOf(contentLength));
+        map.put(KeyTaskId, this._taskId);
+        broadcastIntent.putExtra(BroadcastProgressMap, map);
+        sendBroadcast(broadcastIntent);
+    }
+}
+
+

--- a/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
+++ b/src/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
@@ -40,8 +40,8 @@ public class RNFetchBlobService extends IntentService implements ProgressListene
 
     public static String BroadcastMsg = "BroadcastMsg";
     public static String BroadcastProgressMap = "BroadcastProgressMap";
+    public static String BroadcastTaskId = "BroadcastTaskId";
 
-    public static String KeyTaskId = "KeyTaskId";
     public static String KeyWritten = "KeyWritten";
     public static String KeyTotal = "KeyTotal";
 
@@ -133,6 +133,7 @@ public class RNFetchBlobService extends IntentService implements ProgressListene
                 broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
                 broadcastIntent.addCategory(CategoryFail);
                 broadcastIntent.putExtra(BroadcastMsg, e.getMessage().getBytes());
+                broadcastIntent.putExtra(BroadcastTaskId, _taskId);
                 sendBroadcast(broadcastIntent);
                 call.cancel();
             }
@@ -144,6 +145,7 @@ public class RNFetchBlobService extends IntentService implements ProgressListene
                 broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
                 broadcastIntent.addCategory(CategorySuccess);
                 broadcastIntent.putExtra(BroadcastMsg, response.body().bytes());
+                broadcastIntent.putExtra(BroadcastTaskId, _taskId);
                 sendBroadcast(broadcastIntent);
 
                 response.body().close();
@@ -175,13 +177,11 @@ public class RNFetchBlobService extends IntentService implements ProgressListene
         Intent broadcastIntent = new Intent();
         broadcastIntent.setAction(RNFetchBlobServiceBroadcast);
         broadcastIntent.addCategory(CategoryProgress);
+        broadcastIntent.putExtra(BroadcastTaskId, _taskId);
         HashMap map = new HashMap();
         map.put(KeyWritten, Long.valueOf(bytesWritten));
         map.put(KeyTotal, Long.valueOf(contentLength));
-        map.put(KeyTaskId, this._taskId);
         broadcastIntent.putExtra(BroadcastProgressMap, map);
         sendBroadcast(broadcastIntent);
     }
 }
-
-

--- a/src/ios/RNFetchBlobNetwork.m
+++ b/src/ios/RNFetchBlobNetwork.m
@@ -223,6 +223,10 @@ NSOperationQueue *taskQueue;
     {
         defaultConfigObject.timeoutIntervalForRequest = timeout/1000;
     }
+    
+    defaultConfigObject.sessionSendsLaunchEvents = YES;
+    defaultConfigObject.discretionary = NO;
+    
     defaultConfigObject.HTTPMaximumConnectionsPerHost = 10;
     session = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:taskQueue];
     if(path != nil || [self.options valueForKey:CONFIG_USE_TEMP]!= nil)
@@ -254,7 +258,13 @@ NSOperationQueue *taskQueue;
         respFile = NO;
     }
 
-    __block NSURLSessionDataTask * task = [session dataTaskWithRequest:req];
+    __block NSURLSessionDataTask * task;
+    if (path && req.HTTPMethod == @"POST") {
+        task = [session uploadTaskWithRequest:req fromFile:path];
+    } else {
+        task = [session dataTaskWithRequest:req];
+    }
+    
     [taskTable setObject:task forKey:taskId];
     [task resume];
 

--- a/src/ios/RNFetchBlobNetwork.m
+++ b/src/ios/RNFetchBlobNetwork.m
@@ -225,7 +225,6 @@ NSOperationQueue *taskQueue;
     }
     
     defaultConfigObject.sessionSendsLaunchEvents = YES;
-    defaultConfigObject.discretionary = NO;
     
     defaultConfigObject.HTTPMaximumConnectionsPerHost = 10;
     session = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:taskQueue];


### PR DESCRIPTION
[Related issue](https://github.com/wkh237/react-native-fetch-blob/issues/201)

For long uploading of files while app is in background. (Force-closing the app will fail the post for both platforms).

iOS: if POST and has filepath, will use [NSURLSessionUploadTask](https://developer.apple.com/reference/foundation/nsurlsessionuploadtask) instead of [NSURLSessionDataTask](https://developer.apple.com/reference/foundation/nsurlsessiondatatask?language=objc).

Android: if POSTing multipart/form-data file, `multipartFileUpload` can be set to upload using [IntentService](https://developer.android.com/reference/android/app/IntentService.html)
```
  RNFetchBlob.config({
    multipartFileUpload: true,
  })
```
