### PR TITLE
Remove android:allowBackup="true" from manifest

### DIFF
--- a/src/android/src/main/AndroidManifest.xml
+++ b/src/android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.RNFetchBlob">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
This causes a conflict if the library is used by a project with android:allowBackup="false". I see no reason why a library should set this property at all.

Thank you for making a pull request ! Just a gentle reminder :)

1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
2. Bug fix request to "Bug Fix Branch" 0.10.2
3. Correct README.md can directly to master
