### PR TITLE
Fix Android content-type, closes #293

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -265,7 +265,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                             .chunkedEncoding(isChunkedRequest)
                             .setRequestType(requestType)
                             .setBody(rawRequestBody)
-                            .setMIME(MediaType.parse(getHeaderIgnoreCases(mheaders, "content-type")));
+                            .setMIME(MediaType.parse(getHeaderIgnoreCases(mheaders, "Content-Type")));
                     builder.method(method, requestBody);
                     break;
                 case AsIs:
@@ -273,7 +273,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                             .chunkedEncoding(isChunkedRequest)
                             .setRequestType(requestType)
                             .setBody(rawRequestBody)
-                            .setMIME(MediaType.parse(getHeaderIgnoreCases(mheaders, "content-type")));
+                            .setMIME(MediaType.parse(getHeaderIgnoreCases(mheaders, "Content-Type")));
                     builder.method(method, requestBody);
                     break;
                 case Form:


### PR DESCRIPTION
This PR addresses an issue on Android where `;base64` wasn't correctly being stripped from the `Content-Type` header, as reported in #293 

It looks like the field `"content-type"` was being passed to the `getHeaderIgnoreCases` function in RNFetchBlobReq.java instead of the capitalised field `"Content-Type"` 

---

Thank you for making a pull request ! Just a gentle reminder :)

1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
2. Bug fix request to "Bug Fix Branch" 0.10.3
3. Correct README.md can directly to master