### PR TITLE
making it so there are more options for notifications visibility

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -142,7 +142,12 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
             if (options.addAndroidDownloads.getBoolean("useDownloadManager")) {
                 Uri uri = Uri.parse(url);
                 DownloadManager.Request req = new DownloadManager.Request(uri);
-                req.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+                if(options.addAndroidDownloads.hasKey("notificationsEnum")) {
+                    req.setNotificationVisibility(options.addAndroidDownloads.getInt("notificationsEnum"));
+                }
+                else{
+                    req.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+                }
                 if(options.addAndroidDownloads.hasKey("title")) {
                     req.setTitle(options.addAndroidDownloads.getString("title"));
                 }


### PR DESCRIPTION
Right now, all android download notifications always show up in the task bar of the OS, because the enum VISIBILITY_VISIBLE_NOTIFY_COMPLETED is used. In order to allow the developer to not show notifications if they desire, I have added the ability to add a notificationsEnum property to the addAndroidDownloads writable map that can be filled in with,

0 - VISIBILITY_VISIBLE
1 - VISIBILITY_VISIBLE_NOTIFY_COMPLETED
2 - VISIBILITY_HIDDEN
3 - VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION

If no notificationsEnum property is supplied to addAndroidDownloads, the default will be used. 

https://developer.android.com/reference/android/app/DownloadManager.Request.html#VISIBILITY_VISIBLE_NOTIFY_COMPLETED