### PR TITLE
Re-apply iOS removeCookies API

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -566,9 +566,22 @@ RCT_EXPORT_METHOD(df:(RCTResponseSenderBlock)callback)
 }
 
 # pragma mark - getCookies
+
 RCT_EXPORT_METHOD(getCookies:(NSString *)url resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     resolve([RNFetchBlobNetwork getCookies:url]);
+}
+
+# pragma mark - removeCookie
+
+RCT_EXPORT_METHOD(removeCookies:(NSString *)domain resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSError * err = nil;
+    [RNFetchBlobNetwork removeCookies:domain error:&err];
+    if(err)
+        reject(@"RNFetchBlob failed to remove cookie", @"RNFetchBlob failed to remove cookie", nil);
+    else
+        resolve(@[[NSNull null]]);
 }
 
 # pragma mark - check expired network events
@@ -577,6 +590,8 @@ RCT_EXPORT_METHOD(emitExpiredEvent:(RCTResponseSenderBlock)callback)
 {
     [RNFetchBlobNetwork emitExpiredTasks];
 }
+
+
 
 
 @end

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -49,9 +49,10 @@ typedef void(^DataTaskCompletionHander) (NSData * _Nullable resp, NSURLResponse 
 - (nullable id) init;
 - (void) sendRequest;
 - (void) sendRequest:(NSDictionary  * _Nullable )options contentLength:(long)contentLength bridge:(RCTBridge * _Nullable)bridgeRef taskId:(NSString * _Nullable)taskId withRequest:(NSURLRequest * _Nullable)req callback:(_Nullable RCTResponseSenderBlock) callback;
++ (void) removeCookies:(NSString *) domain error:(NSError **)error;
 + (void) enableProgressReport:(NSString *) taskId config:(RNFetchBlobProgress *)config;
 + (void) enableUploadProgress:(NSString *) taskId config:(RNFetchBlobProgress *)config;
-+ (NSArray *) getCookies:(NSString *) url;
++ (NSDictionary *) getCookies:(NSString *) url;
 
 
 

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -37,7 +37,6 @@
 
 NSMapTable * taskTable;
 NSMapTable * expirationTable;
-NSMapTable * cookiesTable;
 NSMutableDictionary * progressTable;
 NSMutableDictionary * uploadProgressTable;
 
@@ -58,10 +57,6 @@ static void initialize_tables() {
     if(uploadProgressTable == nil)
     {
         uploadProgressTable = [[NSMutableDictionary alloc] init];
-    }
-    if(cookiesTable == nil)
-    {
-        cookiesTable = [[NSMapTable alloc] init];
     }
 }
 
@@ -114,48 +109,6 @@ NSOperationQueue *taskQueue;
         taskQueue.maxConcurrentOperationCount = 10;
     }
     return self;
-}
-
-+ (NSArray *) getCookies:(NSString *) url
-{
-    NSString * hostname = [[NSURL URLWithString:url] host];
-    NSMutableArray * cookies = [NSMutableArray new];
-    NSArray * list = [cookiesTable objectForKey:hostname];
-    for(NSHTTPCookie * cookie in list)
-    {
-        NSMutableString * cookieStr = [[NSMutableString alloc] init];
-        [cookieStr appendString:cookie.name];
-        [cookieStr appendString:@"="];
-        [cookieStr appendString:cookie.value];
-
-        if(cookie.expiresDate == nil) {
-            [cookieStr appendString:@"; max-age=0"];
-        }
-        else {
-            [cookieStr appendString:@"; expires="];
-            NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-            [dateFormatter setDateFormat:@"EEE, dd MM yyyy HH:mm:ss ZZZ"];
-            NSString *strDate = [dateFormatter stringFromDate:cookie.expiresDate];
-            [cookieStr appendString:strDate];
-        }
-
-
-        [cookieStr appendString:@"; domain="];
-        [cookieStr appendString:hostname];
-        [cookieStr appendString:@"; path="];
-        [cookieStr appendString:cookie.path];
-
-
-        if (cookie.isSecure) {
-            [cookieStr appendString:@"; secure"];
-        }
-
-        if (cookie.isHTTPOnly) {
-            [cookieStr appendString:@"; httponly"];
-        }
-        [cookies addObject:cookieStr];
-    }
-    return cookies;
 }
 
 + (void) enableProgressReport:(NSString *) taskId config:(RNFetchBlobProgress *)config
@@ -418,9 +371,10 @@ NSOperationQueue *taskQueue;
         // # 153 get cookies
         if(response.URL != nil)
         {
+            NSHTTPCookieStorage * cookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];
             NSArray<NSHTTPCookie *> * cookies = [NSHTTPCookie cookiesWithResponseHeaderFields: headers forURL:response.URL];
             if(cookies != nil && [cookies count] > 0) {
-                [cookiesTable setObject:cookies forKey:response.URL.host];
+                [cookieStore setCookies:cookies forURL:response.URL mainDocumentURL:nil];
             }
         }
 
@@ -622,6 +576,89 @@ NSOperationQueue *taskQueue;
                 }
          ];
     }
+}
+
+# pragma mark - cookies handling API
+
++ (NSDictionary *) getCookies:(NSString *) domain
+{
+    NSMutableDictionary * result = [NSMutableDictionary new];
+    NSHTTPCookieStorage * cookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    for(NSHTTPCookie * cookie in [cookieStore cookies])
+    {
+        NSString * cDomain = [cookie domain];
+        if([result objectForKey:cDomain] == nil)
+        {
+            [result setObject:[NSMutableArray new] forKey:cDomain];
+        }
+        if([cDomain isEqualToString:domain] || [domain length] == 0)
+        {
+            NSMutableString * cookieStr = [[NSMutableString alloc] init];
+            cookieStr = [[self class] getCookieString:cookie];
+            NSMutableArray * ary = [result objectForKey:cDomain];
+            [ary addObject:cookieStr];
+            [result setObject:ary forKey:cDomain];
+        }
+    }
+    return result;
+}
+
+// remove cookies for given domain, if domain is empty remove all cookies in shared cookie storage.
++ (void) removeCookies:(NSString *) domain error:(NSError **)error
+{
+    @try
+    {
+        NSHTTPCookieStorage * cookies = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+        for(NSHTTPCookie * cookie in [cookies cookies])
+        {
+            BOOL shouldRemove = domain == nil || [domain length] < 1 || [[cookie domain] isEqualToString:domain];
+            if(shouldRemove)
+            {
+                [cookies deleteCookie:cookie];
+            }
+        }
+    }
+    @catch(NSError * err)
+    {
+        *error = err;
+    }
+}
+
+// convert NSHTTPCookie to string
++ (NSString *) getCookieString:(NSHTTPCookie *) cookie
+{
+    NSMutableString * cookieStr = [[NSMutableString alloc] init];
+    [cookieStr appendString:cookie.name];
+    [cookieStr appendString:@"="];
+    [cookieStr appendString:cookie.value];
+    
+    if(cookie.expiresDate == nil) {
+        [cookieStr appendString:@"; max-age=0"];
+    }
+    else {
+        [cookieStr appendString:@"; expires="];
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:@"EEE, dd MM yyyy HH:mm:ss ZZZ"];
+        NSString *strDate = [dateFormatter stringFromDate:cookie.expiresDate];
+        [cookieStr appendString:strDate];
+    }
+    
+    
+    [cookieStr appendString:@"; domain="];
+    [cookieStr appendString: [cookie domain]];
+    [cookieStr appendString:@"; path="];
+    [cookieStr appendString:cookie.path];
+    
+    
+    if (cookie.isSecure) {
+        [cookieStr appendString:@"; secure"];
+    }
+    
+    if (cookie.isHTTPOnly) {
+        [cookieStr appendString:@"; httponly"];
+    }
+    return cookieStr;
+
 }
 
 + (void) cancelRequest:(NSString *)taskId


### PR DESCRIPTION
Seems to have been steamrolled by 8c1db27074af0aa294767b13b575dc090cab8f4f - that change causes an exception in iOS when using `RNFB.net.removeCookies()` since the native bit does not exist. Cherry picked the original commits (80c23f2dc6c34e90f6d79feb972ac126fc6f5ae2 and bc2a5b8c40046c51c3d0928f6caff24c7dc52639) and squashed them together.