### PR TITLE
Add support for the Library directory (iOS only)

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -29,7 +29,8 @@ const dirs = {
     DownloadDir : RNFetchBlob.DownloadDir,
     DCIMDir : RNFetchBlob.DCIMDir,
     SDCardDir : RNFetchBlob.SDCardDir,
-    MainBundleDir : RNFetchBlob.MainBundleDir
+    MainBundleDir : RNFetchBlob.MainBundleDir,
+    LibraryDir : RNFetchBlob.LibraryDir
 }
 
 /**

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -66,7 +66,8 @@ RCT_EXPORT_MODULE();
     return @{
              @"MainBundleDir" : [RNFetchBlobFS getMainBundleDir],
              @"DocumentDir": [RNFetchBlobFS getDocumentDir],
-             @"CacheDir" : [RNFetchBlobFS getCacheDir]
+             @"CacheDir" : [RNFetchBlobFS getCacheDir],
+             @"LibraryDir" : [RNFetchBlobFS getLibraryDir]
              };
 }
 

--- a/ios/RNFetchBlobFS.h
+++ b/ios/RNFetchBlobFS.h
@@ -50,6 +50,7 @@
 + (NSString *) getTempPath;
 + (NSString *) getCacheDir;
 + (NSString *) getDocumentDir;
++ (NSString *) getLibraryDir;
 + (NSString *) getTempPath:(NSString*)taskId withExtension:(NSString *)ext;
 + (NSString *) getPathOfAsset:(NSString *)assetURI;
 + (void) getPathFromUri:(NSString *)uri completionHandler:(void(^)(NSString * path, ALAssetRepresentation *asset)) onComplete;

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -114,6 +114,10 @@ NSMutableDictionary *fileStreams = nil;
     return [NSSearchPathForDirectoriesInDomains(NSPicturesDirectory, NSUserDomainMask, YES) firstObject];
 }
 
++ (NSString *) getLibraryDir {
+    return [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) firstObject];
+}
+
 + (NSString *) getTempPath {
 
     return NSTemporaryDirectory();


### PR DESCRIPTION
Add support for the iOS Library directory (NSLibraryDirectory) which is used for "various documentation, support, and configuration files, resources" from iOS docs.
API in react-native will be RNFetchBlob.fs.dirs.LibraryDir.
