### PR TITLE
add pathForAppGroup (ios only)

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -138,6 +138,15 @@ function mkdir(path:string):Promise {
 }
 
 /**
+ * Returns the path for the app group.
+ * @param  {string} groupName Name of app group
+ * @return {Promise}
+ */
+function pathForAppGroup(groupName:string):Promise {
+  return RNFetchBlob.pathForAppGroup(groupName);
+}
+
+/**
  * Wrapper method of readStream.
  * @param  {string} path Path of the file.
  * @param  {'base64' | 'utf8' | 'ascii'} encoding Encoding of read stream.
@@ -366,6 +375,7 @@ export default {
   writeStream,
   writeFile,
   appendFile,
+  pathForAppGroup,
   readFile,
   exists,
   createFile,

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -184,6 +184,20 @@ RCT_EXPORT_METHOD(createFileASCII:(NSString *)path data:(NSArray *)dataArray cal
 
 }
 
+#pragma mark - fs.pathForAppGroup
+RCT_EXPORT_METHOD(pathForAppGroup:(NSString *)groupName
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSString * path = [RNFetchBlobFS getPathForAppGroup:groupName];
+
+    if(path) {
+        resolve(path);
+    } else {
+        reject(@"RNFetchBlob file not found", @"could not find path for app group", nil);
+    }
+}
+
 #pragma mark - fs.exists
 RCT_EXPORT_METHOD(exists:(NSString *)path callback:(RCTResponseSenderBlock)callback) {
     [RNFetchBlobFS exists:path callback:callback];

--- a/ios/RNFetchBlobFS.h
+++ b/ios/RNFetchBlobFS.h
@@ -52,6 +52,7 @@
 + (NSString *) getDocumentDir;
 + (NSString *) getTempPath:(NSString*)taskId withExtension:(NSString *)ext;
 + (NSString *) getPathOfAsset:(NSString *)assetURI;
++ (NSString *) getPathForAppGroup:(NSString *)groupName;
 + (void) getPathFromUri:(NSString *)uri completionHandler:(void(^)(NSString * path, ALAssetRepresentation *asset)) onComplete;
 
 // fs methods

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -129,6 +129,16 @@ NSMutableDictionary *fileStreams = nil;
     return tempPath;
 }
 
++ (NSString *) getPathForAppGroup:(NSString *)groupName {
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+    NSURL* containerURL = [fileManager containerURLForSecurityApplicationGroupIdentifier:groupName];
+    if(containerURL) {
+        return [containerURL path];
+    } else {
+        return nil;
+    }
+}
+
 #pragma margk - readStream
 
 + (void) readStream:(NSString *)uri


### PR DESCRIPTION
App extensions can share an area of the file system with the main app by making use of an app group.  The name of this shared directory cannot be got staticly (like say the caches dir).  This function returns the path of that directory for the specified  app group.