### PR TITLE
Fix parseUri null pointer crash on Android

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -641,12 +641,14 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                         return;
                     }
                     String contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
-                    Uri uri = Uri.parse(contentUri);
-                    Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
-                    // use default destination of DownloadManager
-                    if (cursor != null) {
-                        cursor.moveToFirst();
-                        filePath = cursor.getString(0);
+                    if (contentUri != null) {
+                        Uri uri = Uri.parse(contentUri);
+                        Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
+                        // use default destination of DownloadManager
+                        if (cursor != null) {
+                            cursor.moveToFirst();
+                            filePath = cursor.getString(0);
+                        }
                     }
                 }
                 // When the file is not found in media content database, check if custom path exists


### PR DESCRIPTION
I've seen this error occur frequently on rebel Android devices. Such as Xperia Z3, Galaxy S4 Mini, HUAWEI P9.

```
Fatal Exception: java.lang.RuntimeException: Error receiving broadcast Intent { act=android.intent.action.DOWNLOAD_COMPLETE flg=0x10 pkg=com.example (has extras) } in com.RNFetchBlob.f@ca10249
       at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:895)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:234)
       at android.app.ActivityThread.main(ActivityThread.java:5526)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
Caused by java.lang.NullPointerException: uriString
       at android.net.Uri$StringUri.(Uri.java)
       at android.net.Uri$StringUri.(Uri.java)
       at android.net.Uri.parse(Uri.java:442)
       at com.RNFetchBlob.RNFetchBlobReq.onReceive(RNFetchBlobReq.java:637)
       at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:885)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:234)
       at android.app.ActivityThread.main(ActivityThread.java:5526)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```
