### PR TITLE
Fix typo in excludeFromBackupKey

### DIFF
--- a/ios.js
+++ b/ios.js
@@ -44,7 +44,7 @@ function openDocument(path:string, scheme:string) {
  * @return {Promise}
  */
 function excludeFromBackupKey(url:string) {
-  return RNFetchBlob.excludeFromBackupKey('file://' + path);
+  return RNFetchBlob.excludeFromBackupKey('file://' + url);
 }
 
 export default {


### PR DESCRIPTION
The code looks like it could never have worked.

I find it a bit odd to call the argument `url` and then do a hard coded prefix with `file://`. Maybe using `path` everywhere would make more sense?