### PR TITLE
Add support for SDCard applications's directory (Android only)

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -207,6 +207,7 @@ public class RNFetchBlobFS {
         state = Environment.getExternalStorageState();
         if (state.equals(Environment.MEDIA_MOUNTED)) {
             res.put("SDCardDir", Environment.getExternalStorageDirectory().getAbsolutePath());
+            res.put("SDCardApplicationDir", ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath());
         }
         res.put("MainBundleDir", ctx.getApplicationInfo().dataDir);
         return res;

--- a/fs.js
+++ b/fs.js
@@ -29,6 +29,7 @@ const dirs = {
     DownloadDir : RNFetchBlob.DownloadDir,
     DCIMDir : RNFetchBlob.DCIMDir,
     SDCardDir : RNFetchBlob.SDCardDir,
+    SDCardApplicationDir : RNFetchBlob.SDCardApplicationDir,
     MainBundleDir : RNFetchBlob.MainBundleDir,
     LibraryDir : RNFetchBlob.LibraryDir
 }


### PR DESCRIPTION
Add support for SDCard application's directory path - Returns the absolute path to the directory on the primary external filesystem where the application can place persistent files it owns. 
This differs from DocumentDir as it is located on the external storage + there is no security enforced with these files.  For example, any application holding WRITE_EXTERNAL_STORAGE permission can write to these files.
React native api will be RNFetchBlob.fs.dirs.SDCardApplicationDir.
