### PR TITLE
[Android] Update android gradle tooling version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,10 +6,10 @@ repositories {
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 


### PR DESCRIPTION
Change to jCenter because mavenCentral does not have the latest version of the package