### PR TITLE
Downgrade android gradle build tools

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 


### PR DESCRIPTION
To support the default react-native gradle version
Discussion found here https://github.com/wkh237/react-native-fetch-blob/pull/396