### PR TITLE
Remove broken Android methods

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -171,11 +171,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void writeChunk(String streamId, String data, Callback callback) {
-        RNFetchBlobFS.writeStreamChunk(streamId, data, callback);
-    }
-
-    @ReactMethod
     public void closeStream(String streamId, Callback callback) {
         RNFetchBlobFS.closeStream(streamId, callback);
     }
@@ -376,28 +371,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     @ReactMethod
     public void fetchBlobForm(ReadableMap options, String taskId, String method, String url, ReadableMap headers, ReadableArray body, final Callback callback) {
         new RNFetchBlobReq(options, taskId, method, url, headers, null, body, callback).run();
-    }
-
-    @ReactMethod
-    public void read(final String path, final String encoding, final int offset, final int length, final @Nullable String dest, final Promise promise) {
-        fsThreadPool.execute(new Runnable() {
-            @Override
-            public void run() {
-                RNFetchBlobFS fs = new RNFetchBlobFS(RCTContext);
-                fs.read(path, encoding, offset, length, dest, promise);
-            }
-        });
-    }
-
-    @ReactMethod
-    public void write(final String path, final String data, final String encoding, final int offset, final int length, final Promise promise) {
-        fsThreadPool.execute(new Runnable() {
-            @Override
-            public void run() {
-                RNFetchBlobFS fs = new RNFetchBlobFS(RCTContext);
-                fs.write(path, encoding, data, offset, length, promise);
-            }
-        });
     }
 
     public void getContentIntent(String mime, Promise promise) {


### PR DESCRIPTION
 - Multiple `writeChunk` overloads are not allowed by react native, only one method per name may be annotated with `@ReactMethod`.
 - `read`/`write` methods reference removed methods in RNFetchBlobFS.

In the current 0.11.0 codebase the android sources won't compile due to errors from `read`/`write` missing methods from RNFetchBlobFS.