### PR TITLE
Fix issue where invoke would be called more than once during cp call

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -444,6 +444,7 @@ public class RNFetchBlobFS {
         path = normalizePath(path);
         InputStream in = null;
         OutputStream out = null;
+        String message = "";
 
         try {
 
@@ -464,7 +465,7 @@ public class RNFetchBlobFS {
             }
 
         } catch (Exception err) {
-            callback.invoke(err.getLocalizedMessage());
+            message += err.getLocalizedMessage();
         } finally {
             try {
                 if (in != null) {
@@ -473,10 +474,15 @@ public class RNFetchBlobFS {
                 if (out != null) {
                     out.close();
                 }
-                callback.invoke();
             } catch (Exception e) {
-                callback.invoke(e.getLocalizedMessage());
+                message += e.getLocalizedMessage();
             }
+        }
+
+        if (message != "") {
+            callback.invoke(message);
+        } else {
+            callback.invoke();
         }
     }
 


### PR DESCRIPTION
Current code raises a `java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.` when `cp` errors but successfully closes its streams.

In the case where there was an exception during copy, `cp` would call invoke twice -- once for the exception and then again in the `finally` block when the streams are closed.
