### PR TITLE
Add support for TLS 1.2 when running Android 4

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -7,10 +7,12 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Base64;
 
 import com.RNFetchBlob.Response.RNFetchBlobDefaultResp;
 import com.RNFetchBlob.Response.RNFetchBlobFileResp;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -21,6 +23,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.network.OkHttpClientProvider;
+import com.facebook.react.modules.network.TLSSocketFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,11 +38,14 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.HashMap;
+
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.ConnectionPool;
+import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -48,6 +54,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.TlsVersion;
+
 
 public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
 
@@ -359,9 +367,10 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
             clientBuilder.retryOnConnectionFailure(false);
             clientBuilder.followRedirects(options.followRedirect);
             clientBuilder.followSslRedirects(options.followRedirect);
+            clientBuilder.retryOnConnectionFailure(true);
 
+            OkHttpClient client = enableTls12OnPreLollipop(clientBuilder).build();
 
-            OkHttpClient client = clientBuilder.retryOnConnectionFailure(true).build();
             Call call =  client.newCall(req);
             taskTable.put(taskId, call);
             call.enqueue(new okhttp3.Callback() {
@@ -670,6 +679,29 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
 
             }
         }
+    }
+
+    public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            try {
+                client.sslSocketFactory(new TLSSocketFactory());
+
+                ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                        .tlsVersions(TlsVersion.TLS_1_2)
+                        .build();
+
+                List< ConnectionSpec > specs = new ArrayList < > ();
+                specs.add(cs);
+                specs.add(ConnectionSpec.COMPATIBLE_TLS);
+                specs.add(ConnectionSpec.CLEARTEXT);
+
+                client.connectionSpecs(specs);
+            } catch (Exception exc) {
+                FLog.e("OkHttpClientProvider", "Error while enabling TLS 1.2", exc);
+            }
+        }
+
+        return client;
     }
 
 


### PR DESCRIPTION
This PR fixes an issue when running Android KitKat against HTTPS servers that require TLS 1.1 or newer. Android KitKat includes TLS 1.1/1.2 support, but doesn't enable it by default.  This PR enables it, modeling the fix on work done previously by the core React Native team to fix a similar [issue](https://github.com/facebook/react-native/issues/7192) with Fetch in RN (which does now work fine in KitKat with TLS 1.1+ thanks to https://github.com/facebook/react-native/pull/9840).