### PR TITLE
[iOS] Fix for failure to write base64 encoded strings

### DIFF
--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -568,11 +568,11 @@ NSMutableDictionary *fileStreams = nil;
 
 // Write file chunk into an opened stream
 - (void)writeEncodeChunk:(NSString *) chunk {
-    NSMutableData * decodedData = [NSData alloc];
+    NSData * decodedData = nil;
     if([[self.encoding lowercaseString] isEqualToString:@"base64"]) {
-        decodedData = [[NSData alloc] initWithBase64EncodedData:chunk options:0];
-    }
-    if([[self.encoding lowercaseString] isEqualToString:@"utf8"]) {
+        decodedData = [[NSData alloc] initWithBase64EncodedString:chunk options: NSDataBase64DecodingIgnoreUnknownCharacters];
+    } 
+    else if([[self.encoding lowercaseString] isEqualToString:@"utf8"]) {
         decodedData = [chunk dataUsingEncoding:NSUTF8StringEncoding];
     }
     else if([[self.encoding lowercaseString] isEqualToString:@"ascii"]) {


### PR DESCRIPTION
On iOS, `RNFetchBlobWriteStream.write()` silently fails for base64 encoded strings. 

`RNFetchBlobFS.writeEncodeChunk()` improperly allocated `NSData` for base64 encoded strings. The local variable `decodedData` would then be nil, resulting in a silent failure with no data written. 

It's possible #334 is related.