### PR TITLE
fix syntaxerror

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.7
+2. Bug fix request to "Bug Fix Branch" 0.10.8
 3. Correct README.md can directly to master

--- a/polyfill/Blob.js
+++ b/polyfill/Blob.js
@@ -286,7 +286,7 @@ export default class Blob extends EventTarget {
 
   safeClose() {
     if(this._closed)
-      return Promise.reject('Blob has been released.)
+      return Promise.reject('Blob has been released.')
     this._closed = true
     if(!this._isReference) {
       return fs.unlink(this._ref).catch((err) => {


### PR DESCRIPTION
Hi, when I use this module, found this bug, so make a PR to fix it ;)

```
SyntaxError: ./node_modules/react-native-fetch-blob/polyfill/Blob.js: Unterminated string constant (289:28)
  287 |   safeClose() {
  288 |     if(this._closed)
> 289 |       return Promise.reject('Blob has been released.)
      |                             ^
  290 |     this._closed = true
  291 |     if(!this._isReference) {
  292 |       return fs.unlink(this._ref).catch((err) => {
```

Thank you for making a pull request ! Just a gentle reminder :)

1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
2. Bug fix request to "Bug Fix Branch" 0.10.8
3. Correct README.md can directly to master
