### PR TITLE
Implemenet fs.hash()

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ File Access APIs
 - [readFile (0.6.0)](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#readfilepath-encodingpromise)
 - [readStream](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#readstreampath-encoding-buffersizepromise)
 - [writeStream](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#writestreampathstring-encodingstring-appendbooleanpromise)
+- [hash](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#hashpath-algorithmpromise)
 - [unlink](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#unlinkpathstringpromise)
 - [mkdir](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#mkdirpathstringpromise)
 - [ls](https://github.com/wkh237/react-native-fetch-blob/wiki/File-System-Access-API#lspathstringpromise)

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -267,11 +267,21 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void hash(final String path, final String algorithm, final Promise promise) {
+        threadPool.execute(new Runnable() {
+            @Override
+            public void run() {
+                RNFetchBlobFS.hash(path, algorithm, promise);
+            }
+        });
+    }
+
     /**
      * @param path Stream file path
      * @param encoding Stream encoding, should be one of `base64`, `ascii`, and `utf8`
      * @param bufferSize Stream buffer size, default to 4096 or 4095(base64).
      */
+    @ReactMethod
     public void readStream(final String path, final String encoding, final int bufferSize, final int tick, final String streamId) {
         final ReactApplicationContext ctx = this.getReactApplicationContext();
         fsThreadPool.execute(new Runnable() {

--- a/fs.js
+++ b/fs.js
@@ -239,6 +239,15 @@ function scanFile(pairs:any):Promise {
   })
 }
 
+function hash(path: string, algorithm: string): Promise<string> {
+  if(typeof path !== 'string')
+    return Promise.reject(new Error('Invalid argument "path" '))
+  if(typeof algorithm !== 'string')
+    return Promise.reject(new Error('Invalid argument "algorithm" '))
+
+  return RNFetchBlob.hash(path, algorithm)
+}
+
 function cp(path:string, dest:string):Promise<boolean> {
   return new Promise((resolve, reject) => {
     RNFetchBlob.cp(path, dest, (err, res) => {
@@ -379,6 +388,7 @@ export default {
   appendFile,
   pathForAppGroup,
   readFile,
+  hash,
   exists,
   createFile,
   isDir,

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -461,6 +461,15 @@ RCT_EXPORT_METHOD(readFile:(NSString *)path
     }];
 }
 
+#pragma mark - fs.hash
+RCT_EXPORT_METHOD(hash:(NSString *)path
+                  algorithm:(NSString *)algorithm
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [RNFetchBlobFS hash:path algorithm:[NSString stringWithString:algorithm] resolver:resolve rejecter:reject];
+}
+
 #pragma mark - fs.readStream
 RCT_EXPORT_METHOD(readStream:(NSString *)path withEncoding:(NSString *)encoding bufferSize:(int)bufferSize tick:(int)tick streamId:(NSString *)streamId)
 {

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -489,6 +489,76 @@ NSMutableDictionary *fileStreams = nil;
     }];
 }
 
+# pragma mark - hash
+
+RCT_EXPORT_METHOD(hash:(NSString *)filepath
+                  algorithm:(NSString *)algorithm
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:filepath];
+
+  if (!fileExists) {
+    return reject(@"ENOENT", [NSString stringWithFormat:@"ENOENT: no such file or directory, open '%@'", filepath], nil);
+  }
+
+  NSError *error = nil;
+
+  NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filepath error:&error];
+
+  if (error) {
+    return [self reject:reject withError:error];
+  }
+
+  if ([attributes objectForKey:NSFileType] == NSFileTypeDirectory) {
+    return reject(@"EISDIR", @"EISDIR: illegal operation on a directory, read", nil);
+  }
+
+  NSData *content = [[NSFileManager defaultManager] contentsAtPath:filepath];
+
+  NSArray *keys = [NSArray arrayWithObjects:@"md5", @"sha1", @"sha224", @"sha256", @"sha384", @"sha512", nil];
+
+  NSArray *digestLengths = [NSArray arrayWithObjects:
+    @CC_MD5_DIGEST_LENGTH,
+    @CC_SHA1_DIGEST_LENGTH,
+    @CC_SHA224_DIGEST_LENGTH,
+    @CC_SHA256_DIGEST_LENGTH,
+    @CC_SHA384_DIGEST_LENGTH,
+    @CC_SHA512_DIGEST_LENGTH,
+    nil];
+
+  NSDictionary *keysToDigestLengths = [NSDictionary dictionaryWithObjects:digestLengths forKeys:keys];
+
+  int digestLength = [[keysToDigestLengths objectForKey:algorithm] intValue];
+
+  if (!digestLength) {
+    return reject(@"Error", [NSString stringWithFormat:@"Invalid hash algorithm '%@'", algorithm], nil);
+  }
+
+  unsigned char buffer[digestLength];
+
+  if ([algorithm isEqualToString:@"md5"]) {
+    CC_MD5(content.bytes, (CC_LONG)content.length, buffer);
+  } else if ([algorithm isEqualToString:@"sha1"]) {
+    CC_SHA1(content.bytes, (CC_LONG)content.length, buffer);
+  } else if ([algorithm isEqualToString:@"sha224"]) {
+    CC_SHA224(content.bytes, (CC_LONG)content.length, buffer);
+  } else if ([algorithm isEqualToString:@"sha256"]) {
+    CC_SHA256(content.bytes, (CC_LONG)content.length, buffer);
+  } else if ([algorithm isEqualToString:@"sha384"]) {
+    CC_SHA384(content.bytes, (CC_LONG)content.length, buffer);
+  } else if ([algorithm isEqualToString:@"sha512"]) {
+    CC_SHA512(content.bytes, (CC_LONG)content.length, buffer);
+  } else {
+    return reject(@"Error", [NSString stringWithFormat:@"Invalid hash algorithm '%@'", algorithm], nil);
+  }
+
+  NSMutableString *output = [NSMutableString stringWithCapacity:digestLength * 2];
+  for(int i = 0; i < digestLength; i++)
+    [output appendFormat:@"%02x",buffer[i]];
+
+  resolve(output);
+}
 
 # pragma mark - mkdir
 


### PR DESCRIPTION
This implements [`fs.hash(...)` (link)](https://github.com/itinance/react-native-fs#hashfilepath-string-algorithm-string-promisestring) from ticket https://github.com/wkh237/react-native-fetch-blob/issues/439

While this is a FEATURE patch I propose this to go into 0.10.9, since it involves zero code changes for any other code. If you disagree I'll resubmit the PR for 0.11.

I only tested it on Android, the code is from https://github.com/itinance/react-native-fs
