### PR TITLE
bug: UIApplication methods are called on background thread

### DIFF
--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -245,8 +245,11 @@ NSOperationQueue *taskQueue;
     [task resume];
 
     // network status indicator
-    if([[options objectForKey:CONFIG_INDICATOR] boolValue] == YES)
-        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+    if ([[options objectForKey:CONFIG_INDICATOR] boolValue] == YES) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+        });
+    }
     __block UIApplication * app = [UIApplication sharedApplication];
 
 }
@@ -483,7 +486,9 @@ NSOperationQueue *taskQueue;
     NSString * respStr = [NSNull null];
     NSString * rnfbRespType = @"";
 
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    });
 
     if(respInfo == nil)
     {


### PR DESCRIPTION
As long as RNFetchBlob is called inside of a mounted component, the issue doesn't present itself. However, if one of these methods are called from outside a mounted component, Xcode will complain about `setNetworkActivityIndicatorVisible` being called from a background thread:

```
Main Thread Checker: UI API called on a background thread: -[UIApplication setNetworkActivityIndicatorVisible:]
PID: 829, TID: 23395, Thread name: (none), Queue name: NSOperationQueue 0x1c043df80 (QOS: UNSPECIFIED), QoS: 0
Backtrace:
4   MyApp                               0x0000000101ff48b8 -[RNFetchBlobNetwork URLSession:task:didCompleteWithError:] + 356
5   CFNetwork                           0x0000000185b97b78 <redacted> + 72
6   Foundation                          0x0000000185e862c0 <redacted> + 16
7   Foundation                          0x0000000185dc6b70 <redacted> + 72
8   Foundation                          0x0000000185db6828 <redacted> + 868
9   libdispatch.dylib                   0x0000000102971d4c _dispatch_client_callout + 16
10  libdispatch.dylib                   0x000000010297e984 _dispatch_block_invoke_direct + 240
11  libdispatch.dylib                   0x0000000102971d4c _dispatch_client_callout + 16
12  libdispatch.dylib                   0x000000010297e984 _dispatch_block_invoke_direct + 240
13  libdispatch.dylib                   0x000000010297e860 dispatch_block_perform + 104
14  Foundation                          0x0000000185e87f98 <redacted> + 376
15  libdispatch.dylib                   0x0000000102971d4c _dispatch_client_callout + 16
16  libdispatch.dylib                   0x000000010297f9a0 _dispatch_continuation_pop + 624
17  libdispatch.dylib                   0x000000010297de48 _dispatch_async_redirect_invoke + 684
18  libdispatch.dylib                   0x0000000102984080 _dispatch_root_queue_drain + 616
19  libdispatch.dylib                   0x0000000102983db8 _dispatch_worker_thread4 + 68
20  libsystem_pthread.dylib             0x00000001841ff338 _pthread_wqthread + 1260
21  libsystem_pthread.dylib             0x00000001841fee40 start_wqthread + 4
```

Best practice is to always wrap these methods in a `dispatch_async` call to ensure they are called on the foreground thread.