### PR TITLE
Add ability to cancel android DownloadManager fetches

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -79,6 +79,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
     }
 
     public static HashMap<String, Call> taskTable = new HashMap<>();
+    public static HashMap<String, Long> androidDownloadManagerTaskTable = new HashMap<>();
     static HashMap<String, RNFetchBlobProgressConfig> progressReport = new HashMap<>();
     static HashMap<String, RNFetchBlobProgressConfig> uploadProgressReport = new HashMap<>();
     static ConnectionPool pool = new ConnectionPool();
@@ -135,6 +136,13 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
             call.cancel();
             taskTable.remove(taskId);
         }
+
+        if (androidDownloadManagerTaskTable.containsKey(taskId)) {
+            long downloadManagerIdForTaskId = androidDownloadManagerTaskTable.get(taskId).longValue();
+            Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
+            DownloadManager dm = (DownloadManager) appCtx.getSystemService(Context.DOWNLOAD_SERVICE);
+            dm.remove(downloadManagerIdForTaskId);
+        }
     }
 
     @Override
@@ -172,6 +180,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
                 DownloadManager dm = (DownloadManager) appCtx.getSystemService(Context.DOWNLOAD_SERVICE);
                 downloadManagerId = dm.enqueue(req);
+                androidDownloadManagerTaskTable.put(taskId, Long.valueOf(downloadManagerId));
                 appCtx.registerReceiver(this, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
                 return;
             }
@@ -438,6 +447,8 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
     private void releaseTaskResource() {
         if(taskTable.containsKey(taskId))
             taskTable.remove(taskId);
+        if(androidDownloadManagerTaskTable.containsKey(taskId))
+            androidDownloadManagerTaskTable.remove(taskId);
         if(uploadProgressReport.containsKey(taskId))
             uploadProgressReport.remove(taskId);
         if(progressReport.containsKey(taskId))
@@ -635,6 +646,8 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
             Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
             long id = intent.getExtras().getLong(DownloadManager.EXTRA_DOWNLOAD_ID);
             if (id == this.downloadManagerId) {
+                releaseTaskResource(); // remove task ID from task map
+
                 DownloadManager.Query query = new DownloadManager.Query();
                 query.setFilterById(downloadManagerId);
                 DownloadManager dm = (DownloadManager) appCtx.getSystemService(Context.DOWNLOAD_SERVICE);


### PR DESCRIPTION
Not completely sure whether this is considered a new feature or a bugfix, but since this behavior may be expected I figured it might be a bugfix. Happy to move PR to 0.11.0 if desired.

This just requires a bit of bookkeeping that keeps track of the task ID to the download manager ID, and then calling the relevant download manager method. Note that the behavior of the download manager remove method is to remove the download and the downloaded file, whether partial or complete (https://developer.android.com/reference/android/app/DownloadManager.html#remove(long...)). 

Happy to answer any questions and always looking for review/comments on the approach.