### PR TITLE
`task cancelled` issue due to improper type casting

### DIFF
--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -505,7 +505,7 @@ NSOperationQueue *taskQueue;
         errMsg = [error localizedDescription];
     }
     NSDictionary * taskSession = [taskTable objectForKey:taskId];
-    BOOL isCancelled = [taskSession valueForKey:@"isCancelled"];
+    BOOL isCancelled = [[taskSession valueForKey:@"isCancelled"] boolValue];
     if(isCancelled) {
         errMsg = @"task cancelled";
     }


### PR DESCRIPTION
Hello!

First of all - thank you for this excellent library and an amazing job!

I've faced slight problem with `0.10.9` branch - when i've tried to fetch multiple assets on my list view, all requests failed due to `task cancelled` error even though there was no such event.

I've checked Objective-C implementation and found out there is an issue with type casting in `RNFetchBlobNetwork.m`:

```objective-c
BOOL isCancelled = [taskSession valueForKey:@"isCancelled"];

NSLog(@"%@", taskSession);
NSLog(@"%d", isCancelled);
if(isCancelled) {
    errMsg = @"task cancelled";
}

NSLog(@"%@", errMsg);
```
which resulted in:

```
2017-09-08 14:49:40.266 Pudelek[57084:957459] {
    isCancelled = 0;
    session = "<__NSCFLocalDataTask: 0x7ffd313161c0>{ taskIdentifier: 1 } { completed }";
}
2017-09-08 14:49:40.266 Pudelek[57084:957459] 1
2017-09-08 14:49:40.267 Pudelek[57084:957459] "task cancelled"
```

This simple pull requests fixed the problem for me.