### PR TITLE
fixed getExternalFilesDir null issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.8
+2. Bug fix request to "Bug Fix Branch" 0.10.9
 3. Correct README.md can directly to master

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ RNFetchBlob
     console.log('The file saved to ', res.path())
     // Beware that when using a file path as Image source on Android,
     // you must prepend "file://"" before the file path
-    imageView = <Image source={{ uri : Platform.OS === 'android' ? 'file://' + res.path()  : '' + res.path() }}/>
+    imageView = <Image source={{ uri : Platform.OS === 'android' ? 'file://' + res.path() : '' + res.path() }}/>
   })
 ```
 

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -213,7 +213,12 @@ public class RNFetchBlobFS {
         state = Environment.getExternalStorageState();
         if (state.equals(Environment.MEDIA_MOUNTED)) {
             res.put("SDCardDir", Environment.getExternalStorageDirectory().getAbsolutePath());
-            res.put("SDCardApplicationDir", ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath());
+            File externalFilesDir = ctx.getExternalFilesDir(null);
+            if(externalFilesDir != null) {
+                res.put("SDCardApplicationDir", externalFilesDir.getParentFile().getAbsolutePath());
+            } else {
+                res.put("SDCardApplicationDir", Environment.getExternalStorageDirectory().getAbsolutePath());
+            }
         }
         res.put("MainBundleDir", ctx.getApplicationInfo().dataDir);
         return res;

--- a/ios.js
+++ b/ios.js
@@ -43,7 +43,7 @@ function openDocument(path:string, scheme:string) {
  * @param  {string} url URL of the resource, only file URL is supported
  * @return {Promise}
  */
-function excludeFromBackupKey(url:string) {
+function excludeFromBackupKey(path:string) {
   return RNFetchBlob.excludeFromBackupKey('file://' + path);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-blob",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
this issue has happened in a cloud tests' machines, here was log in https://github.com/phodal/play-app/issues/1

```
10-11 20:42:05.803 31781 31781 E unknown:ReactNative: Got DOWN touch before receiving UP or CANCEL from last gesture
10-11 20:42:05.995 31781 31781 V ActivityThread: Finishing stop of ActivityRecord{9b47a49 token=android.os.BinderProxy@3c907f4e {com.phodal.play/com.phodal.play.MainActivity}}: show=false win=com.android.internal.policy.impl.MiuiPhoneWindow@1eafb3c4
10-11 20:42:05.995 31781 31781 V PhoneWindow: DecorView setVisiblity: visibility = 4 ,Parent =ViewRoot{3bd3f9ac com.phodal.play/com.phodal.play.MainActivity,ident = 0}, this =com.android.internal.policy.impl.PhoneWindow$DecorView{af9425a I.E..... R....... 0,0-1080,1920}
10-11 20:42:06.111 31781 31781 E unknown:ReactNative: Got DOWN touch before receiving UP or CANCEL from last gesture
10-11 20:42:06.226 31781 31811 D BluetoothAdapter: getName
10-11 20:42:06.237 31781 31811 V SettingsInterface: invalidate [secure]: current 14 != cached 0
10-11 20:42:06.363 31781 31811 W ContextImpl: Failed to ensure directory: /storage/emulated/0/Android/data/com.phodal.play/files
10-11 20:42:06.367 31781 31811 E ReactNativeJS: Java exception in 'NativeModules'
10-11 20:42:06.367 31781 31811 E ReactNativeJS:
10-11 20:42:06.367 31781 31811 E ReactNativeJS: java.lang.NullPointerException: Attempt to invoke virtual method 'java.io.File java.io.File.getParentFile()' on a null object reference
10-11 20:42:06.377 31781 31811 E ReactNativeJS: Module AppRegistry is not a registered callable module (calling runApplication)
10-11 20:42:06.378 31781 31811 E ReactNativeJS: Module AppRegistry is not a registered callable module (calling runApplication)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: FATAL EXCEPTION: mqt_native_modules
10-11 20:42:06.384 31781 31812 E AndroidRuntime: Process: com.phodal.play, PID: 31781
10-11 20:42:06.384 31781 31812 E AndroidRuntime: com.facebook.react.common.JavascriptException: Java exception in 'NativeModules'
10-11 20:42:06.384 31781 31812 E AndroidRuntime:
10-11 20:42:06.384 31781 31812 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'java.io.File java.io.File.getParentFile()' on a null object reference, stack:
10-11 20:42:06.384 31781 31812 E AndroidRuntime: com.RNFetchBlob.RNFetchBlobFS.getSystemfolders@216
10-11 20:42:06.384 31781 31812 E AndroidRuntime: com.RNFetchBlob.RNFetchBlob.getConstants@84
10-11 20:42:06.384 31781 31812 E AndroidRuntime: com.facebook.react.bridge.JavaModuleWrapper.getConstants@140
10-11 20:42:06.384 31781 31812 E AndroidRuntime: android.os.Handler.handleCallback@815
10-11 20:42:06.384 31781 31812 E AndroidRuntime: android.os.Handler.dispatchMessage@104
10-11 20:42:06.384 31781 31812 E AndroidRuntime: com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage@31
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@856:101
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@855:3413
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@852:3421
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@851:196
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@850:135
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@485:467
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@451:341
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@448:267
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@59:184
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:348
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: <unknown>@12:38
10-11 20:42:06.384 31781 31812 E AndroidRuntime: i@2:565
10-11 20:42:06.384 31781 31812 E AndroidRuntime: n@2:278
10-11 20:42:06.384 31781 31812 E AndroidRuntime: t@2:210
10-11 20:42:06.384 31781 31812 E AndroidRuntime: global code@898:9
10-11 20:42:06.384 31781 31812 E AndroidRuntime:
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.modules.core.ExceptionsManagerModule.showOrThrowError(ExceptionsManagerModule.java:56)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.modules.core.ExceptionsManagerModule.reportFatalException(ExceptionsManagerModule.java:40)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at java.lang.reflect.Method.invoke(Native Method)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at java.lang.reflect.Method.invoke(Method.java:372)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:363)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:162)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at android.os.Handler.handleCallback(Handler.java:815)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at android.os.Handler.dispatchMessage(Handler.java:104)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at android.os.Looper.loop(Looper.java:194)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:194)
10-11 20:42:06.384 31781 31812 E AndroidRuntime: at java.lang.Thread.run(Thread.java:818)
```

when I search getExternalFilesDir null in Google, it seems it's common problem. I don't very sure the path is correctly ? but just want to confirm it.
 
It seems in a error branch..