### PR TITLE
fix(polyfill): JSON responses were not marked as ready on complete

### DIFF
--- a/polyfill/XMLHttpRequest.js
+++ b/polyfill/XMLHttpRequest.js
@@ -358,6 +358,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget{
         case 'json':
           this._response = resp.json()
           this._responseText = resp.text()
+          responseDataReady();
         break
         default :
           this._responseText = resp.text()


### PR DESCRIPTION
`XMLHttpRequest` polyfills fails to dispatch the ready state changes,
and all related logic as to when a response is complete when the response
type is JSON. For some reason, the logic involved was never invoked, and
I can only assume is an oversight. I'd like to know if there wasn't any
particular reasoning, as I'll be using this version regardless in my fork,
since it solves #563 for me.