### PR TITLE
Ability to upload request body as iOS Upload Task

### DIFF
--- a/ios/RNFetchBlob.xcodeproj/project.pbxproj
+++ b/ios/RNFetchBlob.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 				A15C300F1CD25C330074CB35 /* Products */,
 				8BD9ABDFAF76406291A798F2 /* Libraries */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
 		};
 		A15C300F1CD25C330074CB35 /* Products */ = {

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -262,7 +262,7 @@ NSOperationQueue *taskQueue;
         task = [session uploadTaskWithRequest:req fromFile:[NSURL fileURLWithPath:path]];
     } else if (uploadTask && [req.HTTPBody length] > 0) {
         NSError *error;
-        task = [self uploadTaskWithBodyOfRequest:req session:session error:&error];
+        task = [self uploadTaskWithBodyOfRequest:req session:session inBackground:backgroundTask error:&error];
         if (!task) {
             callback(@[error.localizedDescription]);
             return;
@@ -281,8 +281,12 @@ NSOperationQueue *taskQueue;
 
 }
 
-- (NSURLSessionUploadTask *) uploadTaskWithBodyOfRequest:(NSURLRequest *)req session:(NSURLSession *)session error:(NSError **)error
+- (NSURLSessionUploadTask *) uploadTaskWithBodyOfRequest:(NSURLRequest *)req session:(NSURLSession *)session inBackground:(BOOL)background error:(NSError **)error
 {
+    if (!background) {
+        return [session uploadTaskWithRequest:req fromData:req.HTTPBody];
+    }
+
     NSString *tempPath = [RNFetchBlobFS getTempPath];
     NSURL *tempRootDir = [NSURL fileURLWithPath:tempPath isDirectory:YES];
     NSURL *tempDir = [tempRootDir URLByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -259,7 +259,7 @@ NSOperationQueue *taskQueue;
 
     __block NSURLSessionDataTask * task;
     if (path && [req.HTTPMethod isEqualToString:@"POST"]) {
-        task = [session uploadTaskWithRequest:req fromFile:path];
+        task = [session uploadTaskWithRequest:req fromFile:[NSURL fileURLWithPath:path]];
     } else if (uploadTask && [req.HTTPBody length] > 0) {
         NSString *tempPath = [RNFetchBlobFS getTempPath];
         NSURL *tempRootDir = [NSURL fileURLWithPath:tempPath isDirectory:YES];

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -244,7 +244,7 @@ NSOperationQueue *taskQueue;
     }
 
     __block NSURLSessionDataTask * task;
-    if (path && req.HTTPMethod == @"POST") {
+    if (path && [req.HTTPMethod isEqualToString:@"POST"]) {
         task = [session uploadTaskWithRequest:req fromFile:path];
     } else {
         task = [session dataTaskWithRequest:req];

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -156,6 +156,17 @@ NSOperationQueue *taskQueue;
     return ret;
 }
 
+- (void) removeUploadTempFile {
+    if (!uploadTempFile) {
+        return;
+    }
+
+    NSError *error;
+    if (![[NSFileManager defaultManager] removeItemAtURL:uploadTempFile error:&error]) {
+        NSLog(@"Failed to remove upload temporary file: %@", error.localizedDescription);
+    }
+}
+
 // send HTTP request
 - (void) sendRequest:(__weak NSDictionary  * _Nullable )options
        contentLength:(long) contentLength
@@ -563,6 +574,7 @@ NSOperationQueue *taskQueue;
 
 
     callback(@[ errMsg, rnfbRespType, respStr]);
+    [self removeUploadTempFile];
 
     @synchronized(taskTable, uploadProgressTable, progressTable)
     {


### PR DESCRIPTION
Adds the ability to specify `IOSUploadTask` as a config parameter to `RNFetchBlobConfig`. Specifying this parameter will create an `NSURLSessionUploadTask` with the request's body. If the `IOSBackgroundTask` flag is also set, the body is first written to a temporary file. See commit log for more details.