### PR TITLE
Use chained request in interceptor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.8
+2. Bug fix request to "Bug Fix Branch" 0.10.9
 3. Correct README.md can directly to master

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ RNFetchBlob
     console.log('The file saved to ', res.path())
     // Beware that when using a file path as Image source on Android,
     // you must prepend "file://"" before the file path
-    imageView = <Image source={{ uri : Platform.OS === 'android' ? 'file://' + res.path()  : '' + res.path() }}/>
+    imageView = <Image source={{ uri : Platform.OS === 'android' ? 'file://' + res.path() : '' + res.path() }}/>
   })
 ```
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -323,7 +323,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 @Override
                 public Response intercept(Chain chain) throws IOException {
                     try {
-                        Response originalResponse = chain.proceed(req);
+                        Response originalResponse = chain.proceed(chain.request());
                         ResponseBody extended;
                         switch (responseType) {
                             case KeepInMemory:

--- a/ios.js
+++ b/ios.js
@@ -43,7 +43,7 @@ function openDocument(path:string, scheme:string) {
  * @param  {string} url URL of the resource, only file URL is supported
  * @return {Promise}
  */
-function excludeFromBackupKey(url:string) {
+function excludeFromBackupKey(path:string) {
   return RNFetchBlob.excludeFromBackupKey('file://' + path);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-blob",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes many issues regarding OkHttpClient interceptors and their order as executed by RNFetchBlob.