### PR TITLE
Remove unnecessary `extern` keyword

### DIFF
--- a/ios/RNFetchBlobConst.m
+++ b/ios/RNFetchBlobConst.m
@@ -7,38 +7,38 @@
 //
 #import "RNFetchBlobConst.h"
 
-extern NSString *const FILE_PREFIX = @"RNFetchBlob-file://";
-extern NSString *const ASSET_PREFIX = @"bundle-assets://";
-extern NSString *const AL_PREFIX = @"assets-library://";
+NSString *const FILE_PREFIX = @"RNFetchBlob-file://";
+NSString *const ASSET_PREFIX = @"bundle-assets://";
+NSString *const AL_PREFIX = @"assets-library://";
 
 // fetch configs
-extern NSString *const CONFIG_USE_TEMP = @"fileCache";
-extern NSString *const CONFIG_FILE_PATH = @"path";
-extern NSString *const CONFIG_FILE_EXT = @"appendExt";
-extern NSString *const CONFIG_TRUSTY = @"trusty";
-extern NSString *const CONFIG_INDICATOR = @"indicator";
-extern NSString *const CONFIG_KEY = @"key";
-extern NSString *const CONFIG_EXTRA_BLOB_CTYPE = @"binaryContentTypes";
+NSString *const CONFIG_USE_TEMP = @"fileCache";
+NSString *const CONFIG_FILE_PATH = @"path";
+NSString *const CONFIG_FILE_EXT = @"appendExt";
+NSString *const CONFIG_TRUSTY = @"trusty";
+NSString *const CONFIG_INDICATOR = @"indicator";
+NSString *const CONFIG_KEY = @"key";
+NSString *const CONFIG_EXTRA_BLOB_CTYPE = @"binaryContentTypes";
 
-extern NSString *const EVENT_STATE_CHANGE = @"RNFetchBlobState";
-extern NSString *const EVENT_SERVER_PUSH = @"RNFetchBlobServerPush";
-extern NSString *const EVENT_PROGRESS = @"RNFetchBlobProgress";
-extern NSString *const EVENT_PROGRESS_UPLOAD = @"RNFetchBlobProgress-upload";
-extern NSString *const EVENT_EXPIRE = @"RNFetchBlobExpire";
+NSString *const EVENT_STATE_CHANGE = @"RNFetchBlobState";
+NSString *const EVENT_SERVER_PUSH = @"RNFetchBlobServerPush";
+NSString *const EVENT_PROGRESS = @"RNFetchBlobProgress";
+NSString *const EVENT_PROGRESS_UPLOAD = @"RNFetchBlobProgress-upload";
+NSString *const EVENT_EXPIRE = @"RNFetchBlobExpire";
 
-extern NSString *const MSG_EVENT = @"RNFetchBlobMessage";
-extern NSString *const MSG_EVENT_LOG = @"log";
-extern NSString *const MSG_EVENT_WARN = @"warn";
-extern NSString *const MSG_EVENT_ERROR = @"error";
-extern NSString *const FS_EVENT_DATA = @"data";
-extern NSString *const FS_EVENT_END = @"end";
-extern NSString *const FS_EVENT_WARN = @"warn";
-extern NSString *const FS_EVENT_ERROR = @"error";
+NSString *const MSG_EVENT = @"RNFetchBlobMessage";
+NSString *const MSG_EVENT_LOG = @"log";
+NSString *const MSG_EVENT_WARN = @"warn";
+NSString *const MSG_EVENT_ERROR = @"error";
+NSString *const FS_EVENT_DATA = @"data";
+NSString *const FS_EVENT_END = @"end";
+NSString *const FS_EVENT_WARN = @"warn";
+NSString *const FS_EVENT_ERROR = @"error";
 
-extern NSString *const KEY_REPORT_PROGRESS = @"reportProgress";
-extern NSString *const KEY_REPORT_UPLOAD_PROGRESS = @"reportUploadProgress";
+NSString *const KEY_REPORT_PROGRESS = @"reportProgress";
+NSString *const KEY_REPORT_UPLOAD_PROGRESS = @"reportUploadProgress";
 
 // response type
-extern NSString *const RESP_TYPE_BASE64 = @"base64";
-extern NSString *const RESP_TYPE_UTF8 = @"utf8";
-extern NSString *const RESP_TYPE_PATH = @"path";
+NSString *const RESP_TYPE_BASE64 = @"base64";
+NSString *const RESP_TYPE_UTF8 = @"utf8";
+NSString *const RESP_TYPE_PATH = @"path";


### PR DESCRIPTION
Keyword `extern` is needed to add in .h files. Xcode 9 shows "'extern' variable has an initializer" warning for lines that contain `extern` in .m files.
![2017-11-23 12 51 39](https://user-images.githubusercontent.com/809319/33166966-15dd344a-d04d-11e7-8590-c81c726c10d2.png)
