### PR TITLE
Add lodash to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "base-64": "0.1.0",
-    "glob": "7.0.6"
+    "glob": "7.0.6",
+    "lodash": "4.17.4"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
It is used in project, but not mentioned in package.json, so React Packager sometimes fails.