### PR TITLE
Bug Fix Branch 0.11.0 - Solve Android security exposed app error

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 18 12:33:41 CST 2016
+#Wed Nov 29 11:45:41 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -30,6 +30,16 @@
             android:name=".RNFetchBlobService"
             >
         </service>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.RNFetchBlob.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -3,7 +3,10 @@ package com.RNFetchBlob;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
+import android.support.v4.content.FileProvider;
 
 import com.RNFetchBlob.Utils.DataConverter;
 import com.facebook.react.bridge.ActivityEventListener;
@@ -20,6 +23,7 @@ import com.facebook.react.modules.network.CookieJarContainer;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
 import com.facebook.react.modules.network.OkHttpClientProvider;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -101,16 +105,36 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     @ReactMethod
     public void actionViewIntent(String path, String mime, final Promise promise) {
         try {
-            Intent intent= new Intent(Intent.ACTION_VIEW)
-                    .setDataAndType(Uri.parse("file://" + path), mime);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            this.getReactApplicationContext().startActivity(intent);
+            Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(), "com.RNFetchBlob.provider",
+                    new File(path));
+
+            if (Build.VERSION.SDK_INT >= 24) {
+                // Create the intent with data and type
+                Intent intent = new Intent(Intent.ACTION_VIEW)
+                        .setDataAndType(uriForFile, mime);
+
+                // Set flag to give temporary permission to external app to use FileProvider
+                intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                // Validate that the device can open the file
+                PackageManager pm = getCurrentActivity().getPackageManager();
+                if (intent.resolveActivity(pm) != null) {
+                    this.getReactApplicationContext().startActivity(intent);
+                }
+
+            } else {
+                Intent intent = new Intent(Intent.ACTION_VIEW)
+                        .setDataAndType(Uri.parse("file://" + path), mime).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                this.getReactApplicationContext().startActivity(intent);
+            }
+
             ActionViewVisible = true;
 
             final LifecycleEventListener listener = new LifecycleEventListener() {
                 @Override
                 public void onHostResume() {
-                    if(ActionViewVisible)
+                    if (ActionViewVisible)
                         promise.resolve(null);
                     RCTContext.removeLifecycleEventListener(this);
                 }
@@ -126,7 +150,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 }
             };
             RCTContext.addLifecycleEventListener(listener);
-        } catch(Exception ex) {
+        } catch (Exception ex) {
+            ex.printStackTrace();
             promise.reject(ex.getLocalizedMessage());
         }
     }

--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
This PR is addressed to #358 . It solves the exposed security exception on Android devices with API version >= 24. In older API's the code hasn't changed, still uses `file://...`.
