### PR TITLE
Catch exceptions when creating constants for sd card directories

### DIFF
--- a/android.js
+++ b/android.js
@@ -38,9 +38,25 @@ function addCompleteDownload(config) {
     return Promise.reject('RNFetchBlob.android.addCompleteDownload only supports Android.')
 }
 
+function getSDCardDir() {
+  if(Platform.OS === 'android')
+    return RNFetchBlob.getSDCardDir()
+  else
+    return Promise.reject('RNFetchBlob.android.getSDCardDir only supports Android.')
+}
+
+function getSDCardApplicationDir() {
+  if(Platform.OS === 'android')
+    return RNFetchBlob.getSDCardApplicationDir()
+  else
+    return Promise.reject('RNFetchBlob.android.getSDCardApplicationDir only supports Android.')
+}
+
 
 export default {
   actionViewIntent,
   getContentIntent,
-  addCompleteDownload
+  addCompleteDownload,
+  getSDCardDir,
+  getSDCardApplicationDir,
 }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -92,7 +92,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.createFile(path, content, encode, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -136,7 +135,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.createFileASCII(path, dataArray, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -167,7 +165,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.cp(path, dest, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -228,7 +225,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.writeFile(path, encoding, data, append, promise);
             }
         });
-
     }
 
     @ReactMethod
@@ -263,7 +259,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 new RNFetchBlobFS(ctx).scanFile(p, m, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -324,7 +319,7 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     @ReactMethod
     public void fetchBlob(ReadableMap options, String taskId, String method, String url, ReadableMap headers, String body, final Callback callback) {
         new RNFetchBlobReq(options, taskId, method, url, headers, body, null, mClient, callback).run();
-}
+    }
 
     @ReactMethod
     public void fetchBlobForm(ReadableMap options, String taskId, String method, String url, ReadableMap headers, ReadableArray body, final Callback callback) {
@@ -370,4 +365,13 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
 
     }
 
+    @ReactMethod
+    public void getSDCardDir(Promise promise) {
+        RNFetchBlobFS.getSDCardDir(promise);
+    }
+
+    @ReactMethod
+    public void getSDCardApplicationDir(Promise promise) {
+        RNFetchBlobFS.getSDCardApplicationDir(this.getReactApplicationContext(), promise);
+    }
 }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -213,10 +213,36 @@ public class RNFetchBlobFS {
         state = Environment.getExternalStorageState();
         if (state.equals(Environment.MEDIA_MOUNTED)) {
             res.put("SDCardDir", Environment.getExternalStorageDirectory().getAbsolutePath());
-            res.put("SDCardApplicationDir", ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath());
+            try {
+                res.put("SDCardApplicationDir", ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath());
+            } catch(Exception e) {
+                res.put("SDCardApplicationDir", "");
+            }
         }
         res.put("MainBundleDir", ctx.getApplicationInfo().dataDir);
         return res;
+    }
+
+    static public void getSDCardDir(Promise promise) {
+        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+            promise.resolve(Environment.getExternalStorageDirectory().getAbsolutePath());
+        } else {
+            promise.reject("RNFetchBlob.getSDCardDir", "External storage not mounted");
+        }
+
+    }
+
+    static public void getSDCardApplicationDir(ReactApplicationContext ctx, Promise promise) {
+        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+            try {
+                final String path = ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath();
+                promise.resolve(path);
+            } catch (Exception e) {
+                promise.reject("RNFetchBlob.getSDCardApplicationDir", e.getLocalizedMessage());
+            }
+        } else {
+            promise.reject("RNFetchBlob.getSDCardApplicationDir", "External storage not mounted");
+        }
     }
 
     /**

--- a/fs.js
+++ b/fs.js
@@ -28,8 +28,17 @@ const dirs = {
     MovieDir : RNFetchBlob.MovieDir,
     DownloadDir : RNFetchBlob.DownloadDir,
     DCIMDir : RNFetchBlob.DCIMDir,
-    SDCardDir : RNFetchBlob.SDCardDir,
-    SDCardApplicationDir : RNFetchBlob.SDCardApplicationDir,
+    get SDCardDir() {
+      console.warn('SDCardDir as a constant is deprecated and will be removed in feature release. ' +
+                   'Use RNFetchBlob.android.getSDCardDir():Promise instead.');
+      return RNFetchBlob.SDCardDir;
+    },
+    get SDCardApplicationDir() {
+      console.warn('SDCardApplicationDir as a constant is deprecated and will be removed in feature release. ' +
+                   'Use RNFetchBlob.android.getSDCardApplicationDir():Promise instead. ' +
+                   'This variable can be empty on error in native code.');
+      return RNFetchBlob.SDCardApplicationDir;
+    },
     MainBundleDir : RNFetchBlob.MainBundleDir,
     LibraryDir : RNFetchBlob.LibraryDir
 }


### PR DESCRIPTION
Setting ```SDCardApplicationDir``` constant throws sometimes ```NullPointerException```.

Additionally ```SDCardDir``` and ```SDCardApplicationDir``` are set once on module load, but external storage can be ejected, unmounted and paths could be not valid anymore later.

This PR:
1. catches ```NullPointerException``` and sets then empty path (other ideas how to handle exception are welcome) which should be handled in JS then.
2. introduces ```getSDCardDir``` and ```getSDCardApplicationDir``` methods to get this paths when needed from JS.
3. adds deprecation warning when constants are used.
 
QUESTION TO MAINTAINERS:
I've read contributing guidelines just now when was about to create PR, should I split it to separate PRs, to bug fix and feature branches. Somehow all this PR changes could or should be merged together maybe. And this is all about Android only and not sure to do all this library testing and use dev repository.
