### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,12 @@
 apply plugin: 'com.android.library'
 
 repositories {
-    mavenCentral()
+    mavenLocal()
+    jcenter()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$projectDir/../../../node_modules/react-native/android"
+    }
 }
 
 buildscript {


### PR DESCRIPTION
After integrating this library with native-navigation of bamlab -https://github.com/bamlab/native-navigation, on android platform, i got many errors in "react-native-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java"

I fixed them by making some config changes in android/build.gradle & it's working now.
