### PR TITLE
compatible with RN > 0.49

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -42,6 +42,10 @@ dispatch_queue_t fsQueue;
     return rootView.bridge;
 }
 
++(BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
 RCT_EXPORT_MODULE();
 
 - (id) init {


### PR DESCRIPTION
RN > 0.49 requires to implement requiresMainQueueSetup.
this fix and suppress that yellow box warning

```
Module RNFetchBlob requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```

Thank you for making a pull request ! Just a gentle reminder :)

1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
2. Bug fix request to "Bug Fix Branch" 0.10.9
3. Correct README.md can directly to master
